### PR TITLE
google-cloud-storage 1.43.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # A lot of dependencies are not available on s390x and win32 currently
+  skip: True  # [py<36 or s390x or ppc64le or win32]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.41.0" %}
+{% set version = "1.43.0" %}
 
 package:
   name: google-cloud-storage
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/g/google-cloud-storage/google-cloud-storage-{{ version }}.tar.gz
-  sha256: 44019944c6675f1ee733b19bd0720677a52924100d5ffdb006da6a4efa411564
+  sha256: f3b4f4be5c8a1b5727a8f7136c94d3bacdd4b7bf11f9553f51ae4c1d876529d3
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,24 +9,25 @@ source:
   sha256: f3b4f4be5c8a1b5727a8f7136c94d3bacdd4b7bf11f9553f51ae4c1d876529d3
 
 build:
-  noarch: python
   number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - setuptools
     - wheel
   run:
-    - python >=3.6
-    - google-auth >=1.24.0,<2.0dev
-    - google-cloud-core >=1.6.1,<2.0dev
-    - google-resumable-media >=1.3.0,<2.0dev
+    - python
+    - google-auth >=1.25.0,<3.0dev
+    - google-api-core >=1.29.0,<3.0dev
+    - google-cloud-core >=1.6.0,<3.0dev
+    - google-resumable-media >=1.3.0,<3.0dev
     - requests >=2.18.0,<3.0.0dev
-    # Workaround for https://github.com/conda-forge/aiohttp-feedstock/issues/43
-    - yarl <1.6.0,>=1.0
+    - protobuf
+    - six
 
 test:
   requires:


### PR DESCRIPTION
Update google-cloud-storage to 1.43.0

Changelog: https://github.com/googleapis/python-storage/blob/v1.43.0/CHANGELOG.md
License: https://github.com/googleapis/python-storage/blob/v1.43.0/LICENSE
Upstream Issues: https://github.com/googleapis/python-storage/issues
Requirements: https://github.com/googleapis/python-storage/blob/v1.43.0/setup.py

Actions: 
1. Remove `noarch: python`
2. Skip `py<36`
3. Skip building on `s390x`, `ppc64le`, and `win32`: many dependencies are not available currently
4. Fix `python` in `host` and `run`
5. Remove `yarl` from `run`, see https://github.com/conda-forge/google-cloud-storage-feedstock/issues/63
6. Update `run` dependencies