### PR TITLE
google-cloud-storage 2.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5
+  sha256: 1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index adc9905..811a123 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5
+  sha256: 1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17
 
 build:
   number: 0

```



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/tree/2.7.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/google-cloud-storage)
* [Diff between upstream and feature branch](https://github.com/conda-forge/google-cloud-storage-feedstock/compare/main...AnacondaRecipes:2.7.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/compare/master...AnacondaRecipes:2.7.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.7.0 git@github.com:AnacondaRecipes/google-cloud-storage-feedstock.git
```
