### PR TITLE
google-cloud-storage 2.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5
+  sha256: 1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index adc9905..811a123 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5
+  sha256: 1ac2d58d2d693cb1341ebc48659a3527be778d9e2d8989697a2746025928ff17
 
 build:
   number: 0

```

**Jira ticket:** [PKG-380
PKG-231
PKG-184
PKG-183](https://anaconda.atlassian.net/browse/PKG-380
https://anaconda.atlassian.net/browse/PKG-231
https://anaconda.atlassian.net/browse/PKG-184
https://anaconda.atlassian.net/browse/PKG-183) (
google-cloud-storage
google-cloud-storage
google-cloud-storage-
2.6.0
2.5.0
2.4.0)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority D | effort: easy | Category: other | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.7.0
 * Release on PyPi:
    * version: 2.7.0
    * date: 2022-12-07T01:20:08
* [PyPi history](https://pypi.org/project/google-cloud-storage/#history)
 * Popularity: 
    * 3 months downloads: 354661.0
    * All time:  3031031 downloads -  google-cloud-storage  2.7.0  Python Client for Google Cloud Storage  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
8. - [ ] NO `pip` in test
    python
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family APACHE is present
16. - [x] License: Apache-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|:-------------|
| Apache-2.0   |
</details>

**Check dependency issues:**

<details>
../aggregate/google-cloud-storage-feedstock/recipe/meta.yaml
Dependencies: ['google-auth >=1.25.0,<3.0dev', 'requests >=2.18.0,<3.0.0dev', 'setuptools', 'google-resumable-media >=2.3.2', 'wheel', 'google-api-core >=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0', 'google-cloud-core >=2.3.0,<3.0dev', 'pip', 'python', 'protobuf <5.0.0dev']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 15**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/tree/2.7.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/google-cloud-storage)
* [Diff between upstream and feature branch](https://github.com/conda-forge/google-cloud-storage-feedstock/compare/main...AnacondaRecipes:2.7.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/compare/master...AnacondaRecipes:2.7.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/google-cloud-storage-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.7.0 git@github.com:AnacondaRecipes/google-cloud-storage-feedstock.git
```
