### PR TITLE
update to 2.18.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425
+  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr1/09446f6
+  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr2/94b775d
+  - https://staging.continuum.io/prefect/fs/google-api-core-feedstock/pr18/a6aba3e
+  - https://staging.continuum.io/prefect/fs/google-resumable-media-feedstock/pr11/d1e3c91

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/proto-plus-feedstock/pr15/facd425
-  - https://staging.continuum.io/prefect/fs/grpcio-status-feedstock/pr1/09446f6
-  - https://staging.continuum.io/prefect/fs/grpcio-gcp-feedstock/pr2/94b775d
   - https://staging.continuum.io/prefect/fs/google-api-core-feedstock/pr18/a6aba3e
   - https://staging.continuum.io/prefect/fs/google-resumable-media-feedstock/pr11/d1e3c91

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/google-api-core-feedstock/pr18/a6aba3e
-  - https://staging.continuum.io/prefect/fs/google-resumable-media-feedstock/pr11/d1e3c91

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/google_cloud_storage-{{ version }}.tar.gz
   sha256: 0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.6.0" %}
+{% set version = "2.17.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 104ca28ae61243b637f2f01455cc8a05e8f15a2a18ced96cb587241cdd3820f5
+  sha256: 49378abff54ef656b52dca5ef0f2eba9aa83dc2b2c72c78714b03a1a95fe9388
 
 build:
   number: 0
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -22,24 +22,24 @@ requirements:
     - wheel
   run:
     - python
-    - google-auth >=1.25.0,<3.0dev
-    - google-api-core >=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0
+    - google-auth >=2.26.1,<3.0dev
+    - google-api-core >=2.15.0,<3.0.0dev
     - google-cloud-core >=2.3.0,<3.0dev
-    - google-resumable-media >=2.3.2
+    - google-resumable-media >=2.6.0
     - requests >=2.18.0,<3.0.0dev
+    - google-crc32c >=1.0,<2.0dev
     # protobuf extra
     - protobuf <5.0.0dev
 
 test:
   requires:
-    - python
     - pip
   imports:
     - google
     - google.cloud
     - google.cloud.storage
   commands:
-    - python -m pip check
+    - pip check
 
 about:
   home: https://github.com/googleapis/python-storage
@@ -54,7 +54,6 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  license_url: https://github.com/googleapis/python-storage/blob/main/LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.17.0" %}
+{% set version = "2.18.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 49378abff54ef656b52dca5ef0f2eba9aa83dc2b2c72c78714b03a1a95fe9388
+  sha256: 0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578
 
 build:
   number: 0
@@ -29,7 +29,9 @@ requirements:
     - requests >=2.18.0,<3.0.0dev
     - google-crc32c >=1.0,<2.0dev
     # protobuf extra
-    - protobuf <5.0.0dev
+    - protobuf <6.0.0dev
+  run_constrained:
+    - opentelemetry-api >=1.1.0
 
 test:
   requires:


### PR DESCRIPTION
google-cloud-storage 2.18.0

**Destination channel:** main

### Links

- PKG-2710
- https://github.com/googleapis/python-storage/tree/v2.18.0
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/google-api-core-feedstock/pull/18
  - https://github.com/AnacondaRecipes/google-resumable-media-feedstock/pull/11

