### PR TITLE
v3.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-channels:
-  - https://staging.continuum.io/prefect/fs/google-cloud-core-feedstock/pr11/f66f6ea
-  - https://staging.continuum.io/prefect/fs/google-resumable-media-feedstock/pr12/5da0331

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+channels:
+  - https://staging.continuum.io/prefect/fs/google-cloud-core-feedstock/pr11/f66f6ea
+  - https://staging.continuum.io/prefect/fs/google-resumable-media-feedstock/pr12/5da0331

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
+  skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "2.18.0" %}
+{% set version = "3.1.0" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/google_cloud_storage-{{ version }}.tar.gz
-  sha256: 0aa3f7c57f3632f81b455d91558d2b27ada96eee2de3aaa17f689db1470d9578
+  sha256: 944273179897c7c8a07ee15f2e6466a02da0c7c4b9ecceac2a26017cb2972049
 
 build:
   number: 0
@@ -24,11 +24,10 @@ requirements:
     - python
     - google-auth >=2.26.1,<3.0dev
     - google-api-core >=2.15.0,<3.0.0dev
-    - google-cloud-core >=2.3.0,<3.0dev
-    - google-resumable-media >=2.6.0
+    - google-cloud-core >=2.4.2,<3.0dev
+    - google-resumable-media >=2.7.2
     - requests >=2.18.0,<3.0.0dev
     - google-crc32c >=1.0,<2.0dev
-    # protobuf extra
     - protobuf <6.0.0dev
   run_constrained:
     - opentelemetry-api >=1.1.0


### PR DESCRIPTION
google-cloud-storage

**Destination channel:**  defaults

### Links

- [PKG-7573](https://anaconda.atlassian.net/browse/PKG-7573) 
- [Upstream repository](https://github.com/googleapis/python-storage/tree/v3.1.0)

### Explanation of changes:

- Bump version and SHA
- Build for 3.13
- Skip on s390x (missing latest protobuf)
- Update pinnnings


[PKG-7573]: https://anaconda.atlassian.net/browse/PKG-7573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ