### PR TITLE
google-cloud-storage 3.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,14 @@ requirements:
     - wheel
   run:
     - python
-    - google-auth >=2.26.1,<3.0dev
-    - google-api-core >=2.15.0,<3.0.0dev
-    - google-cloud-core >=2.4.2,<3.0dev
-    - google-resumable-media >=2.7.2
-    - requests >=2.18.0,<3.0.0dev
-    - google-crc32c >=1.0,<2.0dev
-    - protobuf <6.0.0dev
+    - google-auth >=2.26.1,<3.0.0
+    - google-api-core >=2.15.0,<3.0.0
+    - google-cloud-core >=2.4.2,<3.0.0
+    - google-resumable-media >=2.7.2,<3.0.0
+    - requests >=2.18.0,<3.0.0
+    - google-crc32c >=1.0,<2.0.0
   run_constrained:
+    - protobuf >= 3.20.2,< 7.0.0
     - opentelemetry-api >=1.1.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "3.1.0" %}
+{% set version = "3.4.1" %}
 
 package:
   name: {{ name | lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/google_cloud_storage-{{ version }}.tar.gz
-  sha256: 944273179897c7c8a07ee15f2e6466a02da0c7c4b9ecceac2a26017cb2972049
+  sha256: 6f041a297e23a4b485fad8c305a7a6e6831855c208bcbe74d00332a909f82268
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [py<37]
-  skip: True  # [linux and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10023](https://anaconda.atlassian.net/browse/PKG-10023)
- [Upstream repository](https://github.com/googleapis/python-storage/tree/v3.4.1)
- [Upstream changelog/diff](https://github.com/googleapis/python-storage/blob/v3.4.1/CHANGELOG.md)

### Explanation of changes:

- New version
- Remove s390x stuff
- Update dependencies


[PKG-10023]: https://anaconda.atlassian.net/browse/PKG-10023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ