### PR TITLE
[PKG-15151] google-cloud-storage 3.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,15 @@
 {% if osx %}
 {% set ignored_tests = ignored_tests + ["--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path_creates_directories"] %}
 {% endif %}
+{# Path.resolve() produces Windows-style paths that don't match test expectations built with os.path.join;
+   mock.patch("os.name", "nt") doesn't intercept os.name inside already-imported transfer_manager module #}
+{% if win %}
+{% set ignored_tests = ignored_tests + [
+  "--deselect=tests/unit/test_transfer_manager.py::test__resolve_path_raises_invalid_path_error_on_windows",
+  "--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path",
+  "--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path_creates_directories"
+] %}
+{% endif %}
 
 package:
   name: {{ name | lower }}
@@ -85,7 +94,7 @@ test:
     - pytest -v {{ ignored_tests | join(" ") }}
 
 about:
-  home: https://github.com/googleapis/python-storage
+  home: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage
   summary: Python Client for Google Cloud Storage
   description: |
     Python client for a durable and highly available object storage service.
@@ -93,7 +102,7 @@ about:
     consistency; when a write succeeds, the latest copy of the object will
     be returned to any GET, globally.
   doc_url: https://cloud.google.com/python/docs/reference/storage/latest/index.html
-  dev_url: https://github.com/googleapis/python-storage
+  dev_url: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,10 @@
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterBinary::test_write",
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterText::test_write"
 ] %}
+{# Path.resolve() expands /var -> /private/var on macOS; test compares against os.path.join which doesn't resolve symlinks #}
+{% if osx %}
+{% set ignored_tests = ignored_tests + ["--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path_creates_directories"] %}
+{% endif %}
 
 package:
   name: {{ name | lower }}
@@ -37,7 +41,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -53,7 +57,7 @@ requirements:
     - google-cloud-core >=2.4.2,<3.0.0
     - google-resumable-media >=2.7.2,<3.0.0
     - requests >=2.22.0,<3.0.0
-    - google-crc32c >=1.1.3,<2.0.0
+    - google-crc32c >=1.6.0,<2.0.0
   run_constrained:
     - protobuf >=3.20.2,<7.0.0
     - opentelemetry-api >=1.1.0,<2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@
 {% endif %}
 
 package:
-  name: {{ name | lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,12 +60,9 @@ requirements:
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterBinary::test_write",
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterText::test_write"
 ] %}
-{# Path.resolve() expands /var -> /private/var on macOS; test compares against os.path.join which doesn't resolve symlinks #}
 {% if osx %}
 {% set ignored_tests = ignored_tests + ["--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path_creates_directories"] %}
 {% endif %}
-{# Path.resolve() produces Windows-style paths that don't match test expectations built with os.path.join;
-   mock.patch("os.name", "nt") doesn't intercept os.name inside already-imported transfer_manager module #}
 {% if win %}
 {% set ignored_tests = ignored_tests + [
   "--deselect=tests/unit/test_transfer_manager.py::test__resolve_path_raises_invalid_path_error_on_windows",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,39 @@
 {% set name = "google-cloud-storage" %}
 {% set version = "3.11.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
+  sha256: 498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b
+
+build:
+  number: 0
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - google-auth >=2.26.1,<3.0.0
+    - google-api-core >=2.27.0,<3.0.0
+    - google-cloud-core >=2.4.2,<3.0.0
+    - google-resumable-media >=2.7.2,<3.0.0
+    - requests >=2.22.0,<3.0.0
+    - google-crc32c >=1.6.0,<2.0.0
+  run_constrained:
+    - protobuf >=3.20.2,<7.0.0
+    - opentelemetry-api >=1.1.0,<2.0.0
+    - grpcio-status >=1.76.0,<2.0.0
+    - grpc-google-iam-v1 >=0.14.0,<1.0.0
+
 {% set ignored_tests = [
   "--ignore=tests/conformance",
   "--ignore=tests/perf",
@@ -39,40 +73,6 @@
   "--deselect=tests/unit/test_transfer_manager.py::test_download_many_to_path_creates_directories"
 ] %}
 {% endif %}
-
-package:
-  name: {{ name }}
-  version: {{ version }}
-
-source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: 498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b
-
-build:
-  number: 0
-  skip: true  # [py<310]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-
-requirements:
-  host:
-    - pip
-    - python
-    - setuptools
-    - wheel
-  run:
-    - python
-    - google-auth >=2.26.1,<3.0.0
-    - google-api-core >=2.27.0,<3.0.0
-    - google-cloud-core >=2.4.2,<3.0.0
-    - google-resumable-media >=2.7.2,<3.0.0
-    - requests >=2.22.0,<3.0.0
-    - google-crc32c >=1.6.0,<2.0.0
-  run_constrained:
-    - protobuf >=3.20.2,<7.0.0
-    - opentelemetry-api >=1.1.0,<2.0.0
-    - grpcio-status >=1.76.0,<2.0.0
-    - grpc-google-iam-v1 >=0.14.0,<1.0.0
-
 test:
   source_files:
     - tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,5 @@
 {% set name = "google-cloud-storage" %}
-{% set version = "3.9.0" %}
-
-package:
-  name: {{ name | lower }}
-  version: {{ version }}
-
-source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
-  sha256: f2d8ca7db2f652be757e92573b2196e10fbc09649b5c016f8b422ad593c641cc
-
-build:
-  number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-
-requirements:
-  host:
-    - pip
-    - python
-    - setuptools
-    - wheel
-  run:
-    - python
-    - google-auth >=2.26.1,<3.0.0
-    - google-api-core >=2.27.0,<3.0.0
-    - google-cloud-core >=2.4.2,<3.0.0
-    - google-resumable-media >=2.7.2,<3.0.0
-    - requests >=2.22.0,<3.0.0
-    - google-crc32c >=1.1.3,<2.0.0
-  run_constrained:
-    - protobuf >=3.20.2,<7.0.0
-    - opentelemetry-api >=1.1.0,<2.0.0
-    - grpcio-status >=1.76.0,<2.0.0
-    - grpc-google-iam-v1 >=0.14.0,<1.0.0
-
+{% set version = "3.11.0" %}
 {% set ignored_tests = [
   "--ignore=tests/conformance",
   "--ignore=tests/perf",
@@ -59,7 +25,40 @@ requirements:
   "--deselect=tests/unit/test_client.py::TestClient::test_update_user_agent_with_existing_user_agent",
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterBinary::test_write",
   "--deselect=tests/unit/test_fileio.py::TestBlobWriterText::test_write"
-]%}
+] %}
+
+package:
+  name: {{ name | lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-','_') }}-{{ version }}.tar.gz
+  sha256: 498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b
+
+build:
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - google-auth >=2.26.1,<3.0.0
+    - google-api-core >=2.27.0,<3.0.0
+    - google-cloud-core >=2.4.2,<3.0.0
+    - google-resumable-media >=2.7.2,<3.0.0
+    - requests >=2.22.0,<3.0.0
+    - google-crc32c >=1.1.3,<2.0.0
+  run_constrained:
+    - protobuf >=3.20.2,<7.0.0
+    - opentelemetry-api >=1.1.0,<2.0.0
+    - grpcio-status >=1.76.0,<2.0.0
+    - grpc-google-iam-v1 >=0.14.0,<1.0.0
 
 test:
   source_files:


### PR DESCRIPTION
## Bump google-cloud-storage 3.9.0 → 3.11.0

### Links
- [PKG-15151](https://anaconda.atlassian.net/browse/PKG-15151) — google-cloud-storage 3.11.0
- [google-cloud-python dev](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-storage)
- [PyPI](https://pypi.org/project/google-cloud-storage/3.11.0/)
- [PyPI Inspector](https://inspector.pypi.io/project/google-cloud-storage/3.11.0/)

### Changes
- `recipe/meta.yaml`: bump version to 3.11.0, update sha256
- `recipe/meta.yaml`: update `skip` to `py<310` (upstream now requires Python >=3.10)
- `recipe/meta.yaml`: tighten `google-crc32c` lower bound `>=1.1.3` → `>=1.6.0`
- `recipe/meta.yaml`: update `home` and `dev_url` to new monorepo location
- `recipe/meta.yaml`: deselect `test_download_many_to_path_creates_directories` on macOS
- `recipe/meta.yaml`: deselect 3 `test_transfer_manager` tests on Windows

### Notes
- Upstream repo consolidated into `googleapis/google-cloud-python` monorepo
- macOS test failure: `Path.resolve()` expands `/var` → `/private/var` symlink; test uses `os.path.join` which doesn't resolve symlinks
- Windows test failures: `Path.resolve()` produces paths inconsistent with test expectations built via `os.path.join`; `mock.patch("os.name", "nt")` doesn't intercept `os.name` inside the already-imported module

[PKG-15151]: https://anaconda.atlassian.net/browse/PKG-15151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ